### PR TITLE
fix: targeted second value in array for incrementPoints

### DIFF
--- a/src/components/MatchingGame.js
+++ b/src/components/MatchingGame.js
@@ -5,7 +5,7 @@ import { pointsContext } from "./PointsProvider";
 
 const MatchingGame = () => {
   const navigate = useNavigate();
-  const [incrementPoints] = useContext(pointsContext);
+  const incrementalPoints = useContext(pointsContext)[1]
 
   const sounds = [
         { id: 1, letter: "h", icon: "hat" },
@@ -69,7 +69,7 @@ const MatchingGame = () => {
             )
           if (matched.length === 5) {
               setFinished(wellDone)
-              incrementPoints()
+              incrementalPoints()
           }
 
           return merged

--- a/src/components/PhaseTwoQuiz.js
+++ b/src/components/PhaseTwoQuiz.js
@@ -96,7 +96,8 @@ const PhaseTwoQuiz= () => {
     const [displayEndPage, setdisplayEndPage] = useState(false)
     const [answered, setAnswered] = useState()
     const [cantContinue, setCantContinue] = useState(true)
-    const [incrementPoints] = useContext(pointsContext)
+    const incrementalPoints = useContext(pointsContext)[1]
+
 
     function newGame() {
         setdisplayEndPage(false)
@@ -113,7 +114,7 @@ const PhaseTwoQuiz= () => {
         }
         else {
             setdisplayEndPage(true)
-            incrementPoints()
+            incrementalPoints()
         }
     }
 

--- a/src/components/ReadingGame.js
+++ b/src/components/ReadingGame.js
@@ -106,7 +106,7 @@ const ReadingGame= () => {
     const [displayEndPage, setdisplayEndPage] = useState(false)
     const [answered, setAnswered] = useState()
     const [cantContinue, setCantContinue] = useState(true)
-    const [incrementPoints] = useContext(pointsContext)
+    const incrementalPoints = useContext(pointsContext)[1]
 
     function newGame() {
         setdisplayEndPage(false)
@@ -123,7 +123,7 @@ const ReadingGame= () => {
         }
         else {
             setdisplayEndPage(true)
-            incrementPoints()
+            incrementalPoints()
         }
     }
 


### PR DESCRIPTION
```
const incrementalPoints = useContext(pointsContext)[1]
```

points was needed in the array but Netlify wouldn't deploy if it was declared but not used. Created new variable and targeted second value in the array.